### PR TITLE
NIFI-13455 Add Apache RAT License Checking

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,18 +1,5 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+
 github:
   description: "Apache NiFi Python Extensions"
   homepage: https://nifi.apache.org/

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,4 @@
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
-<!-- contributor license agreements.  See the NOTICE file distributed with -->
-<!-- this work for additional information regarding copyright ownership. -->
-<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
-<!-- (the "License"); you may not use this file except in compliance with -->
-<!-- the License.  You may obtain a copy of the License at -->
-<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
-<!-- Unless required by applicable law or agreed to in writing, software -->
-<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
-<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
-<!-- See the License for the specific language governing permissions and -->
-<!-- limitations under the License. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # Summary
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,5 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+
 name: build
 
 on:
@@ -46,6 +33,8 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
+      - name: Check Licenses
+        run: sh check-licenses.sh
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.ratignore
+++ b/.ratignore
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+__pycache__/*
+build/*
+dist/*
+downloads/*
+eggs/*
+lib/*
+lib64/*
+parts/*
+sdist/*
+var/*
+wheels/*
+share/python-wheels/*
+.idea/*
+.git/*
+.cache/*

--- a/check-licenses.sh
+++ b/check-licenses.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+
+APACHE_RAT_VERSION="0.16.1"
+APACHE_RAT_JAR="apache-rat-$APACHE_RAT_VERSION.jar"
+APACHE_RAT_JAR_URL="https://repo1.maven.org/maven2/org/apache/rat/apache-rat/$APACHE_RAT_VERSION/$APACHE_RAT_JAR"
+CACHE_DIRECTORY=".cache"
+APACHE_RAT_JAR_PATH="$CACHE_DIRECTORY/$APACHE_RAT_JAR"
+APACHE_RAT_EXCLUDE_FILE=".ratignore"
+
+# Set Java command
+if [ -n "${JAVA_HOME-}" ]; then
+  JAVACMD="$JAVA_HOME/bin/java"
+  if [ ! -x "$JAVACMD" ]; then
+    die "Java command [$JAVACMD}] not found"
+  fi
+elif command -v java > /dev/null; then
+  JAVACMD=$(command -v java)
+else
+  die "Environment variable [JAVA_HOME] and command [java] not found"
+fi
+
+# Set curl command
+if command -v curl > /dev/null; then
+  CURLCMD=$(command -v curl)
+else
+  die "Command [curl] not found"
+fi
+
+# Download Apache Rat JAR
+if [ ! -d $CACHE_DIRECTORY ]; then
+  mkdir $CACHE_DIRECTORY
+fi
+if [ ! -f $APACHE_RAT_JAR_PATH ]; then
+  echo "Downloading Apache Rat from [$APACHE_RAT_JAR_URL]"
+  CURL_RESULTS=$(exec $CURLCMD -f --silent --show-error -o "$APACHE_RAT_JAR_PATH" "$APACHE_RAT_JAR_URL")
+  if [ $? -ne 0 ]; then
+    echo "Failed to download Apache Rat from [$APACHE_RAT_JAR_URL]"
+    exit $?
+  fi
+fi
+
+# Run Apache Rat
+REPORT_RESULTS=$(exec $JAVACMD -jar $APACHE_RAT_JAR_PATH --scan-hidden-directories --exclude-file $APACHE_RAT_EXCLUDE_FILE --dir . 2>&1)
+if [ $? -ne 0 ]; then
+  echo "$REPORT_RESULTS"
+  exit $?
+fi
+
+UNKNOWN_LICENSES_FOUND=$(echo "$REPORT_RESULTS" | grep --count "??")
+echo "Unknown Licenses Found: $UNKNOWN_LICENSES_FOUND"
+
+if [ $UNKNOWN_LICENSES_FOUND -eq 0 ]; then
+  RESULT_CODE=0
+else
+  RESULT_CODE=1
+  echo "$REPORT_RESULTS"
+fi
+
+exit $RESULT_CODE


### PR DESCRIPTION
# Summary

[NIFI-13455](https://issues.apache.org/jira/browse/NIFI-13455) Adds license checking using [Apache Rat](https://creadur.apache.org/rat/apache-rat/index.html). The `check-licenses.sh` shell script downloads the Apache Rat JAR to a cache directory and evaluates the output for unknown licenses. Apache Rat supports the [SPDX-License-Identifier](https://spdx.github.io/spdx-spec/v3.0/annexes/using-SPDX-short-identifiers-in-source-files/) in files with the need for a complete license header.

The `check-licenses.sh` script can be run on a Linux or macOS and is incorporated in the GitHub build workflow.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [X] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [X] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [X] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [X] Pull Request based on current revision of the `main` branch
- [X] Pull Request refers to a feature branch with one commit containing changes
